### PR TITLE
Correctly create relative paths when the root is also relative

### DIFF
--- a/src/DestroyerOfModules.ts
+++ b/src/DestroyerOfModules.ts
@@ -63,11 +63,12 @@ export class DestroyerOfModules {
   public async collectKeptModules({ relativePaths = false }: { relativePaths: boolean }): Promise<ModuleMap> {
     const modules = await this.walker.walkTree();
     const moduleMap: ModuleMap = new Map();
+    const rootPath = path.resolve(this.walker.getRootModule());
     for (const module of modules) {
       if (this.shouldKeepModule(module)) {
         let modulePath = module.path;
         if (relativePaths) {
-          modulePath = modulePath.replace(`${this.walker.getRootModule()}${path.sep}`, '');
+          modulePath = modulePath.replace(`${rootPath}${path.sep}`, '');
         }
         moduleMap.set(modulePath, module);
       }

--- a/test/DestroyerOfModules_spec.ts
+++ b/test/DestroyerOfModules_spec.ts
@@ -106,6 +106,27 @@ describe('DestroyerOfModules', () => {
       );
     });
 
+    describe('relativePaths for collectKeptModules with a relative root directory', () => {
+      let moduleMap: galactus.ModuleMap;
+      let oldCurrentDir: string;
+      beforeEach(async () => {
+        oldCurrentDir = process.cwd();
+        process.chdir(tempPackageDir);
+        const destroyer = new galactus.DestroyerOfModules({
+          rootDirectory: '.',
+        });
+        moduleMap = await destroyer.collectKeptModules({ relativePaths: true });
+      });
+
+      it('should use relative paths', () =>
+        expect(moduleMap.has(path.join('node_modules', 'dep-prod'))).to.be.true,
+      );
+
+      afterEach(() => {
+        process.chdir(oldCurrentDir);
+      });
+    });
+
     afterEach(async () => {
       await fs.remove(tempDir);
     });


### PR DESCRIPTION
Fixes electron-userland/electron-packager#820.